### PR TITLE
feat(kernel-api): add COOP/COEP security headers

### DIFF
--- a/kernel-api/src/lib.rs
+++ b/kernel-api/src/lib.rs
@@ -183,27 +183,43 @@ mod security_header_tests {
     }
 
     async fn assert_security_headers(response: Response) {
+        let headers = response.headers();
         assert_eq!(
-            response
-                .headers()
+            headers
                 .get("cross-origin-opener-policy")
                 .and_then(|v| v.to_str().ok()),
             Some("same-origin")
         );
         assert_eq!(
-            response
-                .headers()
+            headers
                 .get("cross-origin-embedder-policy")
                 .and_then(|v| v.to_str().ok()),
             Some("require-corp")
         );
         assert_eq!(
-            response
-                .headers()
+            headers
                 .get("cross-origin-resource-policy")
                 .and_then(|v| v.to_str().ok()),
             Some("same-origin")
         );
+
+        // Verify existing security headers are present
+        assert!(headers
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok())
+            .is_some());
+        assert!(headers
+            .get("x-frame-options")
+            .and_then(|v| v.to_str().ok())
+            .is_some());
+        assert!(headers
+            .get("content-security-policy")
+            .and_then(|v| v.to_str().ok())
+            .is_some());
+        assert!(headers
+            .get("strict-transport-security")
+            .and_then(|v| v.to_str().ok())
+            .is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #79

feat(kernel-api): add COOP/COEP security headers
## Summary

- Add COOP/COEP/CORP security headers to kernel-api for cross-origin isolation
- cross-origin-opener-policy: same-origin
- cross-origin-embedder-policy: require-corp
- cross-origin-resource-policy: same-origin

## Review Note (Codex)

CodeX raised a valid concern about cross-origin-embedder-policy: require-corp:

> This header restricts cross-origin resource loading. If this API needs to support browser-facing external origin integration (iframe/worker/external resources) in the future, the behavior should be re-confirmed.

**Response:** This is acceptable for the current kernel-api design:

1. **Kernel-only API**: This API is designed as an internal kernel service, not a public browser-facing API
2. **Future-proofing**: If browser integration is needed later, these headers can be selectively applied (e.g., via middleware for specific routes) or adjusted accordingly
3. **Current scope**: The primary consumers are trusted internal services and sandboxed userland code (Web Workers), which operate within the same origin

The COOP/COEP headers provide critical security protections (e.g., preventing Spectre-style attacks) and should remain enabled for the current architecture.

## Test plan

- [x] cargo build -p kernel-api
- [x] cargo test -p kernel-api (18 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added cross-origin isolation headers to responses to enforce stricter embedding and resource policies (COOP/COEP/CORP) for improved security across endpoints.
* **Tests**
  * Added automated tests validating those headers are present on health, protected, and error responses to ensure consistent behavior across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->