### PR TITLE
Guard test-utils feature from production builds

### DIFF
--- a/kernel-api/build.rs
+++ b/kernel-api/build.rs
@@ -14,7 +14,7 @@ fn main() {
         );
     }
     if release_like && std::env::var("CARGO_FEATURE_TEST_UTILS").is_ok() {
-        panic!("test-utils must not be enabled in release builds—it bypasses authentication.");
+        panic!("test-utils must not be enabled in release builds—it bypasses security controls.");
     }
     println!("cargo:rerun-if-env-changed=PROFILE");
     println!("cargo:rerun-if-env-changed=DEBUG");

--- a/kernel-data/build.rs
+++ b/kernel-data/build.rs
@@ -15,7 +15,7 @@ fn main() {
         );
     }
     if release_like && std::env::var("CARGO_FEATURE_TEST_UTILS").is_ok() {
-        panic!("test-utils must not be enabled in release builds—it bypasses authentication.");
+        panic!("test-utils must not be enabled in release builds—it bypasses security controls.");
     }
 
     println!("cargo:rerun-if-env-changed=PROFILE");

--- a/kernel-registry/build.rs
+++ b/kernel-registry/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    // Hard fail if development-only features are enabled in release-like builds.
+    // Hard fail if the development-only feature (`test-utils`) is enabled in release-like builds.
     // PROFILE names can be customized, so guard with DEBUG/OPT_LEVEL instead of
     // relying on CARGO_CFG_DEBUG_ASSERTIONS for build-script execution.
     let release_like = std::env::var("DEBUG")

--- a/kernel-registry/build.rs
+++ b/kernel-registry/build.rs
@@ -1,15 +1,18 @@
 fn main() {
-    // Hard fail if test-utils is enabled in release-like builds.
-    // PROFILE names can be customized, so guard with DEBUG/OPT_LEVEL too.
+    // Hard fail if development-only features are enabled in release-like builds.
+    // PROFILE names can be customized, so guard with DEBUG/OPT_LEVEL instead of
+    // relying on CARGO_CFG_DEBUG_ASSERTIONS for build-script execution.
     let release_like = std::env::var("DEBUG")
         .map(|v| v == "false")
         .unwrap_or(false)
         || std::env::var("OPT_LEVEL")
             .map(|v| v != "0")
             .unwrap_or(false);
+
     if release_like && std::env::var("CARGO_FEATURE_TEST_UTILS").is_ok() {
         panic!("test-utils must not be enabled in release builds—it bypasses security controls.");
     }
+
     println!("cargo:rerun-if-env-changed=PROFILE");
     println!("cargo:rerun-if-env-changed=DEBUG");
     println!("cargo:rerun-if-env-changed=OPT_LEVEL");

--- a/scripts/ci/ci-lint-test-utils-scope.sh
+++ b/scripts/ci/ci-lint-test-utils-scope.sh
@@ -69,6 +69,12 @@ if cargo check --release -p kernel-data --features enable_dev_auth >/tmp/kernel-
   exit 1
 fi
 
+if ! grep -q "enable_dev_auth must not be enabled in release builds" /tmp/kernel-data-enable-dev-auth.log; then
+  echo "Error: kernel-data release build failed for an unexpected reason with enable_dev_auth"
+  cat /tmp/kernel-data-enable-dev-auth.log
+  exit 1
+fi
+
 for pkg in "kernel-api" "kernel-core" "kernel-data" "kernel-registry"; do
   if cargo check --release -p "$pkg" --features test-utils >/tmp/"$pkg"-test-utils.log 2>&1; then
     echo "Error: $pkg release build unexpectedly accepted test-utils"
@@ -81,9 +87,3 @@ for pkg in "kernel-api" "kernel-core" "kernel-data" "kernel-registry"; do
     exit 1
   fi
 done
-
-if ! grep -q "enable_dev_auth must not be enabled in release builds" /tmp/kernel-data-enable-dev-auth.log; then
-  echo "Error: kernel-data release build failed for an unexpected reason with enable_dev_auth"
-  cat /tmp/kernel-data-enable-dev-auth.log
-  exit 1
-fi

--- a/scripts/ci/ci-lint-test-utils-scope.sh
+++ b/scripts/ci/ci-lint-test-utils-scope.sh
@@ -7,12 +7,15 @@ cd "$ROOT_DIR"
 ALLOWED_FILES=(
   "tests/contract/Cargo.toml"
   "kernel-registry/Cargo.toml"
+  "kernel-core/Cargo.toml"
+  "kernel-api/Cargo.toml"
+  "kernel-data/Cargo.toml"
 )
 
 mapfile -t CARGO_FILES < <(find . -name Cargo.toml -not -path './target/*' | sort)
 
 violations=()
-PACKAGES=("kernel-api" "kernel-core")
+PACKAGES=("kernel-api" "kernel-core" "kernel-data" "kernel-registry")
 for file in "${CARGO_FILES[@]}"; do
   file="${file#./}"
   for pkg in "${PACKAGES[@]}"; do
@@ -32,7 +35,7 @@ for file in "${CARGO_FILES[@]}"; do
 done
 
 if (( ${#violations[@]} > 0 )); then
-  echo "Error: kernel-api/kernel-core test-utils feature is only allowed in:"
+  echo "Error: test-utils feature is only allowed in:"
   for allowed_file in "${ALLOWED_FILES[@]}"; do
     echo "  - $allowed_file"
   done
@@ -42,9 +45,11 @@ if (( ${#violations[@]} > 0 )); then
   exit 1
 fi
 
-echo "OK: kernel-api/kernel-core test-utils usage is limited to approved Cargo.toml files"
+echo "OK: test-utils usage is limited to approved Cargo.toml files"
 cargo check --release -p kernel-api
 cargo check --release -p kernel-core
+cargo check --release -p kernel-data
+cargo check --release -p kernel-registry
 
 if cargo check --release -p kernel-api --features enable_dev_auth >/tmp/kernel-api-enable-dev-auth.log 2>&1; then
   echo "Error: kernel-api release build unexpectedly accepted enable_dev_auth"
@@ -63,6 +68,19 @@ if cargo check --release -p kernel-data --features enable_dev_auth >/tmp/kernel-
   cat /tmp/kernel-data-enable-dev-auth.log
   exit 1
 fi
+
+for pkg in "kernel-api" "kernel-core" "kernel-data" "kernel-registry"; do
+  if cargo check --release -p "$pkg" --features test-utils >/tmp/"$pkg"-test-utils.log 2>&1; then
+    echo "Error: $pkg release build unexpectedly accepted test-utils"
+    cat /tmp/"$pkg"-test-utils.log
+    exit 1
+  fi
+  if ! grep -Eq "test-utils .*must not be enabled in release builds|test-utils enabled in release profile" /tmp/"$pkg"-test-utils.log; then
+    echo "Error: $pkg release build failed for an unexpected reason with test-utils"
+    cat /tmp/"$pkg"-test-utils.log
+    exit 1
+  fi
+done
 
 if ! grep -q "enable_dev_auth must not be enabled in release builds" /tmp/kernel-data-enable-dev-auth.log; then
   echo "Error: kernel-data release build failed for an unexpected reason with enable_dev_auth"


### PR DESCRIPTION
Fixes Issue #86 by restricting `test-utils` from compiling into release builds via `build.rs` checks. Adds `kernel-registry/build.rs` and properly wires up `ci-lint-test-utils-scope.sh` to guarantee that enabling the feature in release mode fails the build across all relevant packages.

---
*PR created automatically by Jules for task [9854795568323356683](https://jules.google.com/task/9854795568323356683) started by @pdHaku0*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/flexisuite-org/flexisuite_kernel/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build-time enforcement now prevents test utilities from being enabled in release-like builds across all packages.
  * Clarified and standardized error messages to reference bypassing "security controls" for clearer developer feedback.
  * Expanded CI validation to check release builds and test-utils scope for all relevant packages, failing when release constraints are violated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->